### PR TITLE
added to gitignore and created README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,83 @@
+# Compiled class file
+*.class
+**/*.class
+
+# Log file
+*.log
+**/*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+replay_pid*
+
+# Gradle build files
+.gradle/*
+
+# Eclipse wants to add this
+/.gradle/
+
+# Build files
+*/build/*
+
+# Eclipse files
+.project
+/.project
+.classpath
+/.classpath
+*.prefs
+/*.prefs
+
+# backup files
+*.bak
+**/*.bak
+**/*.bak.*
+
+# Python files
+*.idea
+*.pyc
+__pycache__/
+
+# duplicated files
+* - Copy*
+**/* - Copy*
+
+# DSS files
+*.dss
+**/*.dss
+
+# pyinstaller files
+dist/
+build/
+*.spec
+
+# compiled Jasper files
+*.jasper
+jasperC/**
+jasperC/
+jasperC/*.jasper
+
+# created by the reporting
+Images/**
+CSVData/**
+Datasources/USBRAutomatedReportOutput.xml
+
+# W2 specific
 **/*.opt
 !**/pre.opt
 !**/PREW2CodeCompilerVersion.opt
 **/*.exe
-**/*.bak
-**/*.bak.*
-**/*.log

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Sacramento WTMP Shared
+# Sacramento WTMP CEQUAL W2
 The HEC-WAT cequal folder for the Sacramento River within the Bureau of Reclamation (USBR) Water Temperature Modeling Platform (WTMP).
 This repository is a dependency of the Sacramento WTMP Study repository.
 These files are files for W2 within the WTMP.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# Sacramento WTMP Shared
+The HEC-WAT cequal folder for the Sacramento River within the Bureau of Reclamation (USBR) Water Temperature Modeling Platform (WTMP).
+This repository is a dependency of the Sacramento WTMP Study repository.
+These files are files for W2 within the WTMP.
+
+
+### Forecast
+Each model version has its own folder containing the relevant files. These are those versions:
+* W2 Shasta
+* W2 Shasta 5
+* W2 Keswick Prescribed
+* W2 Keswick Prescribed v45
+* W2 Lewiston Prescribed
+* W2 Shasta Prescribed
+* W2 Trinity Prescribed
+* W2 Whiskeytown
+* W2 Whiskeytown Prescribed
+### Hindcast
+### Planning
+### Shared (if any)
+* w2_study.config file
+
+## Dependencies
+To be added later.
+
+## Usage
+### Usage withing the build process
+To be added later.
+
+### Post build implementation
+To be added later.


### PR DESCRIPTION
This repository previously had no README and a gitignore that did not contain everything that should be excluded.

Added to the gitignore to include files that may get created by Java, Python, Jasper, gradle, and other files that we would not want in the repository. This gitignore combined gitignores from other repositories that are involved in the build process.

README now has a brief description of this repository as well as details on files and usage. Instructions for usage was also added. Any sections with no information should be filled in later.

This should make this repository easier to work with and reduce the number of unwanted files.